### PR TITLE
updates clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 name = "hat-backup"
 version = "0.0.1-pre"
 dependencies = [
- "clap 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-macros 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -16,9 +16,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap"
-version = "0.6.6"
+name = "ansi_term"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "clap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ansi_term 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "gcc"
@@ -113,6 +122,11 @@ dependencies = [
  "libc 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "threadpool"


### PR DESCRIPTION
This PR *only* updates the `clap` dep for argument parsing. Since the previously included version there have been multiple bug fixes and feature improvements. Most notably, suggestions are now made when users make typos.

To demo, run `$ hat snapsht my_snapshot some/path/` (missing the `o` in `snapshot`) and you will see:

```
$ hat snapsht my_snapshot some/path/
The subcommand 'snapsht' isn't valid
	Did you mean 'snapshot' ?

If you received this message in error, try re-running with 'hat -- snapsht'

USAGE:
	hat [FLAGS] [SUBCOMMANDS]

For more information try --help
```

Another visual change is that errors are printed in red text. This is done with a cargo feature gate since not everyone wants coloured output, so it can be disabled at compile time by changing the `clap` dependency in the `Cargo.toml` to:

```toml
[dependencies.clap]
version = "*"
default-features = false
features = ["suggestions"]
```
This would leave the `suggestions` feature enabled, but disable the `color` feature. 

Full `clap` [changelog here](https://github.com/kbknapp/clap-rs/blob/master/CHANGELOG.md)

**NOTE:** This PR *only* updates `clap`. So it fails to build because other deps needed to be updated as well, but I was unsure about the ramifications of such a blind update, so I didn't include those.