### PR TITLE
updates to compile on latest nightly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,16 +3,16 @@ name = "hat-backup"
 version = "0.0.1-pre"
 dependencies = [
  "clap 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "num 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-macros 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-macros 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "quickcheck_macros 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.12 (git+https://github.com/rust-lang/rustc-serialize)",
+ "quickcheck_macros 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.15 (git+https://github.com/rust-lang/rustc-serialize)",
  "sodiumoxide 0.0.4 (git+https://github.com/dnaq/sodiumoxide)",
  "sqlite3 0.1.0 (git+https://github.com/linuxfood/rustsqlite)",
  "threadpool 0.1.4 (git+https://github.com/rust-lang/threadpool)",
- "time 0.1.24 (git+https://github.com/rust-lang/time)",
+ "time 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -21,9 +21,13 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "gcc"
-version = "0.3.4"
+name = "kernel32-sys"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "libc"
@@ -48,16 +52,16 @@ dependencies = [
 
 [[package]]
 name = "num"
-version = "0.1.23"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-macros"
-version = "0.1.22"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -66,12 +70,12 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "quickcheck_macros"
-version = "0.2.14"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quickcheck 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -79,22 +83,21 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "rustc-serialize"
-version = "0.3.12"
-source = "git+https://github.com/rust-lang/rustc-serialize#af950f07b9da419d66124c5ffe8c85dd23e0ddac"
 
 [[package]]
 name = "rustc-serialize"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rustc-serialize"
+version = "0.3.15"
+source = "git+https://github.com/rust-lang/rustc-serialize#376f43a4b94dbe411bd9534ab83f02fbcb5a3b04"
 
 [[package]]
 name = "sodiumoxide"
@@ -121,10 +124,21 @@ source = "git+https://github.com/rust-lang/threadpool#0be72d2149dcda5d3f522fad61
 
 [[package]]
 name = "time"
-version = "0.1.24"
-source = "git+https://github.com/rust-lang/time#a7869dcee07de6df4e81b48bdfe137c70c153643"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-build"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,10 @@ quickcheck_macros = "*"
 clap = "*"
 num = "*"
 num-macros = "*"
+time = "*"
 
 [dependencies.rustc-serialize]
 git = "https://github.com/rust-lang/rustc-serialize"
-
-[dependencies.time]
-git = "https://github.com/rust-lang/time"
-features = ["std-duration"]
 
 [dependencies.sodiumoxide]
 git = "https://github.com/dnaq/sodiumoxide"

--- a/src/hat/hash_index.rs
+++ b/src/hat/hash_index.rs
@@ -17,7 +17,7 @@
 use num::FromPrimitive;
 use std::sync::mpsc;
 use std::thunk::Thunk;
-use std::time::duration::{Duration};
+use time::Duration;
 use rustc_serialize::hex::{ToHex};
 
 use callback_container::{CallbackContainer};

--- a/src/hat/hat.rs
+++ b/src/hat/hat.rs
@@ -41,12 +41,10 @@ use gc_noop;
 
 use std::path::PathBuf;
 use std::fs;
-use std::io;
-use std::io::{Read, Write};
+use std::os::unix::fs::MetadataExt;
+use std::io::{self, Read, Write};
 
-use std::sync;
-use std::sync::mpsc;
-use std::sync::atomic;
+use std::sync::{self, mpsc, atomic};
 use std::thread;
 
 use time;
@@ -397,10 +395,10 @@ impl KeyEntry<FileEntry> for FileEntry {
     None
   }
   fn modified(&self) -> Option<u64> {
-    Some(self.metadata.modified())
+    Some(self.metadata.mtime() as u64)
   }
   fn accessed(&self) -> Option<u64> {
-    Some(self.metadata.accessed())
+    Some(self.metadata.atime() as u64)
   }
 
   fn permissions(&self) -> Option<u64> {

--- a/src/hat/key_index.rs
+++ b/src/hat/key_index.rs
@@ -14,7 +14,7 @@
 
 //! Local state for keys in the snapshot in progress (the "index").
 
-use std::time::duration::{Duration};
+use time::Duration;
 
 use periodic_timer::{PeriodicTimer};
 use process::{Process, MsgHandler};

--- a/src/hat/main.rs
+++ b/src/hat/main.rs
@@ -22,9 +22,9 @@
 
 // Unstable APIs:
 #![feature(convert)]
-#![feature(fs_time)]
-#![feature(std_misc)]
 #![feature(test)]
+#![feature(thunk)]
+#![feature(future)]
 
 #![feature(custom_attribute)]
 #![feature(custom_derive)]

--- a/src/hat/periodic_timer.rs
+++ b/src/hat/periodic_timer.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use time::SteadyTime;
-use std::time::duration::{Duration};
+use time::Duration;
 
 
 pub struct PeriodicTimer {


### PR DESCRIPTION
There are still various deprecation warnings, but it compiles.

Also, once/if this gets merged I'll rebase and update #8 