### PR TITLE
Hash index rewrite

### DIFF
--- a/src/hat/hash/mod.rs
+++ b/src/hat/hash/mod.rs
@@ -727,30 +727,6 @@ impl Index {
         self.flush();
         Reply::CommitOk
     }
-
-    fn handle(&mut self, msg: Msg) -> Reply {
-        match msg {
-            Msg::GetID(hash) => self.handle_get_id(hash),
-            Msg::GetHash(id) => self.handle_get_hash(id),
-            Msg::HashExists(hash) => self.handle_hash_exists(hash),
-            Msg::FetchPayload(hash) => self.handle_fetch_payload(hash),
-            Msg::FetchPersistentRef(hash) => self.handle_fetch_persistent_ref(hash),
-            Msg::Reserve(hash_entry) => self.handle_reserve(hash_entry),
-            Msg::UpdateReserved(hash_entry) => self.handle_update_reserved(hash_entry),
-            Msg::Commit(hash, persistent_ref) => self.handle_commit(hash, persistent_ref),
-            Msg::List => self.handle_list(),
-            Msg::Delete(id) => self.handle_delete(id),
-            Msg::SetTag(id, tag) => self.handle_set_tag(id, tag),
-            Msg::SetAllTags(tag) => self.handle_set_all_tags(tag),
-            Msg::GetTag(id) => self.handle_get_tag(id),
-            Msg::GetIDsByTag(tag) => self.handle_get_ids_by_tag(tag),
-            Msg::ReadGcData(hash_id, family_id) => self.handle_read_gc_data(hash_id, family_id),
-            Msg::UpdateGcData(hash_id, family_id, update_fn) => self.handle_update_gc_data(hash_id, family_id, update_fn),
-            Msg::UpdateFamilyGcData(family_id, update_fns) => self.handle_update_family_gc_data(family_id, update_fns),
-            Msg::ManualCommit => self.handle_manual_commit(),
-            Msg::Flush => self.handle_flush(),
-        }
-    }
 }
 
 impl IndexProcess {

--- a/src/hat/hash/mod.rs
+++ b/src/hat/hash/mod.rs
@@ -718,7 +718,7 @@ impl IndexProcess {
         IndexProcess(Arc::new(Mutex::new((index, shutdown))))
     }
 
-    pub fn send_reply(&self, msg: Msg) -> Result<Reply, MsgError> {
+    pub fn send_reply(&self, msg: Msg) -> Reply {
         let mut guard = self.0.lock().expect("index-process has failed");
 
         match &mut guard.1 {
@@ -730,6 +730,6 @@ impl IndexProcess {
             }
         }
 
-        Ok(guard.0.handle(msg))
+        guard.0.handle(msg)
     }
 }

--- a/src/hat/hash/mod.rs
+++ b/src/hat/hash/mod.rs
@@ -777,83 +777,79 @@ impl IndexProcess {
         guard
     }
 
-    pub fn send_reply(&self, msg: Msg) -> Reply {
-        self.lock().0.handle(msg)
-    }
-
-    pub fn get_id(&mut self, hash: Hash) -> Reply {
+    pub fn get_id(&self, hash: Hash) -> Reply {
         self.lock().0.handle_get_id(hash)
     }
 
-    pub fn get_hash(&mut self, id: i64) -> Reply {
+    pub fn get_hash(&self, id: i64) -> Reply {
         self.lock().0.handle_get_hash(id)
     }
 
-    pub fn hash_exists(&mut self, hash: Hash) -> Reply {
+    pub fn hash_exists(&self, hash: Hash) -> Reply {
         self.lock().0.handle_hash_exists(hash)
     }
 
-    pub fn fetch_payload(&mut self, hash: Hash) -> Reply {
+    pub fn fetch_payload(&self, hash: Hash) -> Reply {
         self.lock().0.handle_fetch_payload(hash)
     }
 
-    pub fn fetch_persistent_ref(&mut self, hash: Hash) -> Reply {
+    pub fn fetch_persistent_ref(&self, hash: Hash) -> Reply {
         self.lock().0.handle_fetch_persistent_ref(hash)
     }
 
-    pub fn reserve(&mut self, hash_entry: Entry) -> Reply {
+    pub fn reserve(&self, hash_entry: Entry) -> Reply {
         self.lock().0.handle_reserve(hash_entry)
     }
 
-    pub fn update_reserved(&mut self, hash_entry: Entry) -> Reply {
+    pub fn update_reserved(&self, hash_entry: Entry) -> Reply {
         self.lock().0.handle_update_reserved(hash_entry)
     }
 
-    pub fn commit(&mut self, hash: Hash, persistent_ref: blob::ChunkRef) -> Reply {
+    pub fn commit(&self, hash: Hash, persistent_ref: blob::ChunkRef) -> Reply {
         self.lock().0.handle_commit(hash, persistent_ref)
     }
 
-    pub fn list(&mut self) -> Reply {
+    pub fn list(&self) -> Reply {
         self.lock().0.handle_list()
     }
 
-    pub fn delete(&mut self, id: i64) -> Reply {
+    pub fn delete(&self, id: i64) -> Reply {
         self.lock().0.handle_delete(id)
     }
 
-    pub fn set_tag(&mut self, id: i64, tag: tags::Tag) -> Reply {
+    pub fn set_tag(&self, id: i64, tag: tags::Tag) -> Reply {
         self.lock().0.handle_set_tag(id, tag)
     }
 
-    pub fn set_all_tags(&mut self, tag: tags::Tag) -> Reply {
+    pub fn set_all_tags(&self, tag: tags::Tag) -> Reply {
         self.lock().0.handle_set_all_tags(tag)
     }
 
-    pub fn get_tag(&mut self, id: i64) -> Reply {
+    pub fn get_tag(&self, id: i64) -> Reply {
         self.lock().0.handle_get_tag(id)
     }
 
-    pub fn get_ids_by_tag(&mut self, tag: i64) -> Reply {
+    pub fn get_ids_by_tag(&self, tag: i64) -> Reply {
         self.lock().0.handle_get_ids_by_tag(tag)
     }
 
-    pub fn read_gc_data(&mut self, hash_id: i64, family_id: i64) -> Reply {
+    pub fn read_gc_data(&self, hash_id: i64, family_id: i64) -> Reply {
         self.lock().0.handle_read_gc_data(hash_id, family_id)
     }
 
-    pub fn update_gc_data(&mut self, hash_id: i64, family_id: i64, update_fn: Box<FnBox<GcData, Option<GcData>>>) -> Reply {
+    pub fn update_gc_data(&self, hash_id: i64, family_id: i64, update_fn: Box<FnBox<GcData, Option<GcData>>>) -> Reply {
         self.lock().0.handle_update_gc_data(hash_id, family_id, update_fn)
     }
 
-    pub fn update_family_gc_data(&mut self, family_id: i64, update_fns: mpsc::Receiver<Box<FnBox<GcData, Option<GcData>>>>) -> Reply {
+    pub fn update_family_gc_data(&self, family_id: i64, update_fns: mpsc::Receiver<Box<FnBox<GcData, Option<GcData>>>>) -> Reply {
         self.lock().0.handle_update_family_gc_data(family_id, update_fns)
     }
 
-    pub fn manual_commit(&mut self) -> Reply {
+    pub fn manual_commit(&self) -> Reply {
         self.lock().0.handle_manual_commit()
     }
 
-    pub fn flush(&mut self) -> Reply {
+    pub fn flush(&self) -> Reply {
         self.lock().0.handle_flush()
     }
 }

--- a/src/hat/hash/mod.rs
+++ b/src/hat/hash/mod.rs
@@ -609,11 +609,11 @@ impl Index {
         self.conn.begin_transaction().unwrap();
     }
 
-    fn handle_get_id(&mut self, hash: Hash) -> Reply {
+    fn handle_get_id(&mut self, hash: &Hash) -> Option<i64> {
         assert!(!hash.bytes.is_empty());
         match self.locate(&hash) {
-            Some(entry) => Reply::HashID(entry.id),
-            None => Reply::HashNotKnown,
+            Some(entry) => Some(entry.id),
+            None => None,
         }
     }
 
@@ -753,7 +753,7 @@ impl IndexProcess {
         guard
     }
 
-    pub fn get_id(&self, hash: Hash) -> Reply {
+    pub fn get_id(&self, hash: &Hash) -> Option<i64> {
         self.lock().0.handle_get_id(hash)
     }
 

--- a/src/hat/hash/tree.rs
+++ b/src/hat/hash/tree.rs
@@ -75,7 +75,7 @@ impl HashRef {
 
 pub trait HashTreeBackend {
     fn fetch_chunk(&mut self, &Hash, Option<ChunkRef>) -> Option<Vec<u8>>;
-    fn fetch_payload(&mut self, Hash) -> Option<Vec<u8>>;
+    fn fetch_payload(&mut self, &Hash) -> Option<Vec<u8>>;
     fn fetch_persistent_ref(&mut self, &Hash) -> Option<ChunkRef>;
     fn insert_chunk(&mut self, Hash, i64, Option<Vec<u8>>, Vec<u8>) -> ChunkRef;
 }
@@ -488,7 +488,7 @@ mod tests {
             guarded_chunks.get(&hash.bytes).map(|&(_, _, ref chunk)| chunk.clone())
         }
 
-        fn fetch_payload(&mut self, hash: Hash) -> Option<Vec<u8>> {
+        fn fetch_payload(&mut self, hash: &Hash) -> Option<Vec<u8>> {
             let guarded_chunks = self.chunks.lock().unwrap();
             guarded_chunks.get(&hash.bytes).and_then(|&(_, ref payload, _)| payload.clone())
         }

--- a/src/hat/hat.rs
+++ b/src/hat/hat.rs
@@ -141,9 +141,8 @@ impl gc::GcBackend for GcBackend {
 
     fn reverse_refs(&self, hash_id: i64) -> Result<Vec<i64>, Self::Err> {
         let entry = match self.hash_index.get_hash(hash_id) {
-            hash::Reply::Entry(entry) => entry,
-            hash::Reply::HashNotKnown => panic!("HashNotKnown in hash index."),
-            _ => panic!("Unexpected reply from hash index."),
+            Some(entry) => entry,
+            None => panic!("HashNotKnown in hash index."),
         };
         if entry.payload.is_none() {
             return Ok(Vec::new());

--- a/src/hat/hat.rs
+++ b/src/hat/hat.rs
@@ -425,9 +425,8 @@ impl<B: 'static + blob::StoreBackend + Clone + Send> HatRc<B> {
             }
             // Now insert the hash information if needed.
             match hashes.reserve(entry) {
-                hash::Reply::HashKnown => return Ok(get_hash_id(hashes, &hash).unwrap()),
-                hash::Reply::ReserveOk => (),
-                _ => return Err(From::from("Unexpected reply from hash index")),
+                hash::ReserveResult::HashKnown => return Ok(get_hash_id(hashes, &hash).unwrap()),
+                hash::ReserveResult::ReserveOk => (),
             }
             // Commit hash.
             hashes.commit(&hash, pref.clone());

--- a/src/hat/hat.rs
+++ b/src/hat/hat.rs
@@ -249,7 +249,7 @@ impl<B: 'static + blob::StoreBackend + Clone + Send> HatRc<B> {
         let hash_index_path = hash_index_name(repository_root);
         let si_p = try!(Process::new(move || snapshot::Index::new(snapshot_index_path)));
         let bi_p = try!(Process::new(move || blob::Index::new(blob_index_path)));
-        let hi_p = try!(Process::new(move || hash::Index::new(hash_index_path)));
+        let hi_p = hash::IndexProcess::new(try!(hash::Index::new(hash_index_path)));
 
         let local_blob_index = bi_p.clone();
         let local_backend = backend.clone();
@@ -291,9 +291,8 @@ impl<B: 'static + blob::StoreBackend + Clone + Send> HatRc<B> {
         let bi_p = Process::new_with_shutdown(move || blob::Index::new_for_testing(),
                                               shutdown.next().cloned())
                        .unwrap();
-        let hi_p = Process::new_with_shutdown(move || hash::Index::new_for_testing(),
-                                              shutdown.next().cloned())
-                       .unwrap();
+        let hi_p = hash::IndexProcess::new_with_shutdown(hash::Index::new_for_testing().unwrap(),
+                                                         shutdown.next().cloned());
 
         let local_blob_index = bi_p.clone();
         let local_backend = backend.clone();

--- a/src/hat/hat.rs
+++ b/src/hat/hat.rs
@@ -93,7 +93,7 @@ impl gc::GcBackend for GcBackend {
     type Err = HatError;
 
     fn get_data(&self, hash_id: i64, family_id: i64) -> Result<hash::GcData, Self::Err> {
-        match self.hash_index.send_reply(hash::Msg::ReadGcData(hash_id, family_id)) {
+        match self.hash_index.read_gc_data(hash_id, family_id) {
             hash::Reply::CurrentGcData(data) => Ok(data),
             _ => panic!("Unexpected reply from hash index."),
         }
@@ -103,44 +103,44 @@ impl gc::GcBackend for GcBackend {
                    family_id: i64,
                    f: gc::UpdateFn)
                    -> Result<hash::GcData, Self::Err> {
-        match self.hash_index.send_reply(hash::Msg::UpdateGcData(hash_id, family_id, f)) {
+        match self.hash_index.update_gc_data(hash_id, family_id, f) {
             hash::Reply::CurrentGcData(data) => Ok(data),
             _ => panic!("Unexpected reply from hash index."),
         }
     }
     fn update_all_data_by_family(&mut self,
                                  family_id: i64,
-                                 fs: mpsc::Receiver<gc::UpdateFn>)
+                                 fns: mpsc::Receiver<gc::UpdateFn>)
                                  -> Result<(), Self::Err> {
-        match self.hash_index.send_reply(hash::Msg::UpdateFamilyGcData(family_id, fs)) {
+        match self.hash_index.update_family_gc_data(family_id, fns) {
             hash::Reply::Ok => Ok(()),
             _ => panic!("Unexpected reply from hash index."),
         }
     }
 
     fn get_tag(&self, hash_id: i64) -> Result<Option<tags::Tag>, Self::Err> {
-        match self.hash_index.send_reply(hash::Msg::GetTag(hash_id)) {
+        match self.hash_index.get_tag(hash_id) {
             hash::Reply::HashTag(tag) => Ok(tag),
             _ => panic!("Unexpected reply from hash index."),
         }
     }
 
     fn set_tag(&mut self, hash_id: i64, tag: tags::Tag) -> Result<(), Self::Err> {
-        match self.hash_index.send_reply(hash::Msg::SetTag(hash_id, tag)) {
+        match self.hash_index.set_tag(hash_id, tag) {
             hash::Reply::Ok => Ok(()),
             _ => panic!("Unexpected reply from hash index."),
         }
     }
 
     fn set_all_tags(&mut self, tag: tags::Tag) -> Result<(), Self::Err> {
-        match self.hash_index.send_reply(hash::Msg::SetAllTags(tag)) {
+        match self.hash_index.set_all_tags(tag) {
             hash::Reply::Ok => Ok(()),
             _ => panic!("Unexpected reply from hash index."),
         }
     }
 
     fn reverse_refs(&self, hash_id: i64) -> Result<Vec<i64>, Self::Err> {
-        let entry = match self.hash_index.send_reply(hash::Msg::GetHash(hash_id)) {
+        let entry = match self.hash_index.get_hash(hash_id) {
             hash::Reply::Entry(entry) => entry,
             hash::Reply::HashNotKnown => panic!("HashNotKnown in hash index."),
             _ => panic!("Unexpected reply from hash index."),
@@ -152,8 +152,7 @@ impl gc::GcBackend for GcBackend {
         Ok(hash::tree::decode_metadata_refs(&entry.payload.unwrap())
                .into_iter()
                .map(|bytes| {
-                   match self.hash_index
-                             .send_reply(hash::Msg::GetID(hash::Hash { bytes: bytes })) {
+                   match self.hash_index.get_id(hash::Hash { bytes: bytes }) {
                        hash::Reply::HashID(id) => id,
                        hash::Reply::HashNotKnown => panic!("HashNotKnown in hash index."),
                        _ => panic!("Unexpected result from hash index."),
@@ -164,7 +163,7 @@ impl gc::GcBackend for GcBackend {
 
     fn list_ids_by_tag(&self, tag: tags::Tag) -> Result<mpsc::Receiver<i64>, Self::Err> {
         let (sender, receiver) = mpsc::channel();
-        match self.hash_index.send_reply(hash::Msg::GetIDsByTag(tag as i64)) {
+        match self.hash_index.get_ids_by_tag(tag as i64) {
             hash::Reply::HashIDs(ids) => {
                 ids.iter().map(|i| sender.send(*i)).last();
             }
@@ -175,7 +174,7 @@ impl gc::GcBackend for GcBackend {
     }
 
     fn manual_commit(&mut self) -> Result<(), Self::Err> {
-        match self.hash_index.send_reply(hash::Msg::ManualCommit) {
+        match self.hash_index.manual_commit() {
             hash::Reply::CommitOk => Ok(()),
             _ => panic!("Unexpected reply from hash index."),
         }
@@ -232,7 +231,7 @@ fn list_snapshot(backend: &key::HashStoreBackend,
 }
 
 fn get_hash_id(index: &hash::IndexProcess, hash: hash::Hash) -> Result<i64, HatError> {
-    match index.send_reply(hash::Msg::GetID(hash)) {
+    match index.get_id(hash) {
         hash::Reply::HashID(id) => Ok(id),
         _ => Err(From::from("Tried to register an unknown hash")),
     }
@@ -449,13 +448,13 @@ impl<B: 'static + blob::StoreBackend + Clone + Send> HatRc<B> {
                 _ => return Err(From::from("Failed to add recovered blob")),
             }
             // Now insert the hash information if needed.
-            match hashes.send_reply(hash::Msg::Reserve(entry)) {
+            match hashes.reserve(entry) {
                 hash::Reply::HashKnown => return Ok(get_hash_id(hashes, hash).unwrap()),
                 hash::Reply::ReserveOk => (),
                 _ => return Err(From::from("Unexpected reply from hash index")),
             }
             // Commit hash.
-            match hashes.send_reply(hash::Msg::Commit(hash.clone(), pref.clone())) {
+            match hashes.commit(hash.clone(), pref.clone()) {
                 hash::Reply::CommitOk => (),
                 _ => return Err(From::from("Unexpected reply from hash index")),
             }
@@ -912,12 +911,12 @@ impl<B: 'static + blob::StoreBackend + Clone + Send> HatRc<B> {
 
             let (id_sender, id_receiver) = mpsc::channel();
             for hash in receiver.iter() {
-                match local_hash_index.send_reply(hash::Msg::GetID(hash)) {
+                match local_hash_index.get_id(hash) {
                     hash::Reply::HashID(id) => id_sender.send(id).unwrap(),
                     _ => panic!("Unexpected reply from hash index."),
                 }
             }
-            match local_hash_index.send_reply(hash::Msg::GetID(local_dir_hash)) {
+            match local_hash_index.get_id(local_dir_hash) {
                 hash::Reply::HashID(id) => id_sender.send(id).unwrap(),
                 _ => panic!("Unexpected reply from hash index."),
             }
@@ -978,17 +977,17 @@ impl<B: 'static + blob::StoreBackend + Clone + Send> HatRc<B> {
         try!(self.gc.list_unused_ids(sender));
         for id in receiver.iter() {
             deleted_hashes += 1;
-            match self.hash_index.send_reply(hash::Msg::Delete(id)) {
+            match self.hash_index.delete(id) {
                 hash::Reply::Ok => (),
                 _ => panic!("Unexpected reply from hash index."),
             }
         }
-        match self.hash_index.send_reply(hash::Msg::Flush) {
+        match self.hash_index.flush() {
             hash::Reply::CommitOk => (),
             _ => panic!("Unexpected reply from hash index."),
         }
         // Mark used blobs.
-        let entries = match self.hash_index.send_reply(hash::Msg::List) {
+        let entries = match self.hash_index.list() {
             hash::Reply::Listing(ch) => ch,
             _ => panic!("Unexpected reply from hash index."),
         };

--- a/src/hat/hat.rs
+++ b/src/hat/hat.rs
@@ -93,50 +93,35 @@ impl gc::GcBackend for GcBackend {
     type Err = HatError;
 
     fn get_data(&self, hash_id: i64, family_id: i64) -> Result<hash::GcData, Self::Err> {
-        match self.hash_index.read_gc_data(hash_id, family_id) {
-            hash::Reply::CurrentGcData(data) => Ok(data),
-            _ => panic!("Unexpected reply from hash index."),
-        }
+        Ok(self.hash_index.read_gc_data(hash_id, family_id))
     }
     fn update_data(&mut self,
                    hash_id: i64,
                    family_id: i64,
                    f: gc::UpdateFn)
                    -> Result<hash::GcData, Self::Err> {
-        match self.hash_index.update_gc_data(hash_id, family_id, f) {
-            hash::Reply::CurrentGcData(data) => Ok(data),
-            _ => panic!("Unexpected reply from hash index."),
-        }
+        Ok(self.hash_index.update_gc_data(hash_id, family_id, f))
     }
     fn update_all_data_by_family(&mut self,
                                  family_id: i64,
                                  fns: mpsc::Receiver<gc::UpdateFn>)
                                  -> Result<(), Self::Err> {
-        match self.hash_index.update_family_gc_data(family_id, fns) {
-            hash::Reply::Ok => Ok(()),
-            _ => panic!("Unexpected reply from hash index."),
-        }
+        self.hash_index.update_family_gc_data(family_id, fns);
+        Ok(())
     }
 
     fn get_tag(&self, hash_id: i64) -> Result<Option<tags::Tag>, Self::Err> {
-        match self.hash_index.get_tag(hash_id) {
-            hash::Reply::HashTag(tag) => Ok(tag),
-            _ => panic!("Unexpected reply from hash index."),
-        }
+        Ok(self.hash_index.get_tag(hash_id))
     }
 
     fn set_tag(&mut self, hash_id: i64, tag: tags::Tag) -> Result<(), Self::Err> {
-        match self.hash_index.set_tag(hash_id, tag) {
-            hash::Reply::Ok => Ok(()),
-            _ => panic!("Unexpected reply from hash index."),
-        }
+        self.hash_index.set_tag(hash_id, tag);
+        Ok(())
     }
 
     fn set_all_tags(&mut self, tag: tags::Tag) -> Result<(), Self::Err> {
-        match self.hash_index.set_all_tags(tag) {
-            hash::Reply::Ok => Ok(()),
-            _ => panic!("Unexpected reply from hash index."),
-        }
+        self.hash_index.set_all_tags(tag);
+        Ok(())
     }
 
     fn reverse_refs(&self, hash_id: i64) -> Result<Vec<i64>, Self::Err> {
@@ -161,21 +146,14 @@ impl gc::GcBackend for GcBackend {
 
     fn list_ids_by_tag(&self, tag: tags::Tag) -> Result<mpsc::Receiver<i64>, Self::Err> {
         let (sender, receiver) = mpsc::channel();
-        match self.hash_index.get_ids_by_tag(tag as i64) {
-            hash::Reply::HashIDs(ids) => {
-                ids.iter().map(|i| sender.send(*i)).last();
-            }
-            _ => panic!("Unexpected reply from hash index."),
-        }
+        self.hash_index.get_ids_by_tag(tag as i64).iter().map(|i| sender.send(*i)).last();
 
         Ok(receiver)
     }
 
     fn manual_commit(&mut self) -> Result<(), Self::Err> {
-        match self.hash_index.manual_commit() {
-            hash::Reply::CommitOk => Ok(()),
-            _ => panic!("Unexpected reply from hash index."),
-        }
+        self.hash_index.manual_commit();
+        Ok(())
     }
 }
 
@@ -452,10 +430,7 @@ impl<B: 'static + blob::StoreBackend + Clone + Send> HatRc<B> {
                 _ => return Err(From::from("Unexpected reply from hash index")),
             }
             // Commit hash.
-            match hashes.commit(hash.clone(), pref.clone()) {
-                hash::Reply::CommitOk => (),
-                _ => return Err(From::from("Unexpected reply from hash index")),
-            }
+            hashes.commit(&hash, pref.clone());
 
             Ok(get_hash_id(hashes, &hash).unwrap())
         }
@@ -975,20 +950,11 @@ impl<B: 'static + blob::StoreBackend + Clone + Send> HatRc<B> {
         try!(self.gc.list_unused_ids(sender));
         for id in receiver.iter() {
             deleted_hashes += 1;
-            match self.hash_index.delete(id) {
-                hash::Reply::Ok => (),
-                _ => panic!("Unexpected reply from hash index."),
-            }
+            self.hash_index.delete(id);
         }
-        match self.hash_index.flush() {
-            hash::Reply::CommitOk => (),
-            _ => panic!("Unexpected reply from hash index."),
-        }
+        self.hash_index.flush();
         // Mark used blobs.
-        let entries = match self.hash_index.list() {
-            hash::Reply::Listing(ch) => ch,
-            _ => panic!("Unexpected reply from hash index."),
-        };
+        let entries = self.hash_index.list();
         match self.blob_store.send_reply(blob::Msg::TagAll(tags::Tag::InProgress)) {
             blob::Reply::Ok => (),
             _ => panic!("Unexpected reply from blob store."),

--- a/src/hat/key/mod.rs
+++ b/src/hat/key/mod.rs
@@ -132,7 +132,7 @@ impl Store {
 
     pub fn flush(&mut self) -> Result<(), MsgError> {
         self.blob_store.send_reply(blob::Msg::Flush);
-        self.hash_index.send_reply(hash::Msg::Flush);
+        self.hash_index.flush();
         try!(self.index.send_reply(index::Msg::Flush));
 
         Ok(())
@@ -160,7 +160,7 @@ impl HashStoreBackend {
 
     fn fetch_chunk_from_hash(&mut self, hash: hash::Hash) -> Option<Vec<u8>> {
         assert!(!hash.bytes.is_empty());
-        match self.hash_index.send_reply(hash::Msg::FetchPersistentRef(hash)) {
+        match self.hash_index.fetch_persistent_ref(hash) {
             hash::Reply::PersistentRef(chunk_ref) => {
                 self.fetch_chunk_from_persistent_ref(chunk_ref)
             }
@@ -205,7 +205,7 @@ impl HashTreeBackend for HashStoreBackend {
     fn fetch_persistent_ref(&mut self, hash: &hash::Hash) -> Option<blob::ChunkRef> {
         assert!(!hash.bytes.is_empty());
         loop {
-            match self.hash_index.send_reply(hash::Msg::FetchPersistentRef(hash.clone())) {
+            match self.hash_index.fetch_persistent_ref(hash.clone()) {
                 hash::Reply::PersistentRef(r) => return Some(r), // done
                 hash::Reply::HashNotKnown => return None, // done
                 hash::Reply::Retry => (),  // continue loop
@@ -215,7 +215,7 @@ impl HashTreeBackend for HashStoreBackend {
     }
 
     fn fetch_payload(&mut self, hash: hash::Hash) -> Option<Vec<u8>> {
-        match self.hash_index.send_reply(hash::Msg::FetchPayload(hash)) {
+        match self.hash_index.fetch_payload(hash) {
             hash::Reply::Payload(p) => p, // done
             hash::Reply::HashNotKnown => None, // done
             _ => panic!("Unexpected reply from hash index."),
@@ -237,7 +237,7 @@ impl HashTreeBackend for HashStoreBackend {
             persistent_ref: None,
         };
 
-        match self.hash_index.send_reply(hash::Msg::Reserve(hash_entry.clone())) {
+        match self.hash_index.reserve(hash_entry.clone()) {
             hash::Reply::HashKnown => {
                 // Someone came before us: piggyback on their result.
                 return self.fetch_persistent_ref(&hash)
@@ -248,7 +248,7 @@ impl HashTreeBackend for HashStoreBackend {
                 let local_hash_index = self.hash_index.clone();
 
                 let callback = Box::new(move |chunk_ref: blob::ChunkRef| {
-                    local_hash_index.send_reply(hash::Msg::Commit(hash, chunk_ref));
+                    local_hash_index.commit(hash, chunk_ref);
                 });
                 let kind = if level == 0 {
                     blob::Kind::TreeLeaf
@@ -258,7 +258,7 @@ impl HashTreeBackend for HashStoreBackend {
                 match self.blob_store.send_reply(blob::Msg::Store(chunk, kind, callback)) {
                     blob::Reply::StoreOk(chunk_ref) => {
                         hash_entry.persistent_ref = Some(chunk_ref.clone());
-                        self.hash_index.send_reply(hash::Msg::UpdateReserved(hash_entry));
+                        self.hash_index.update_reserved(hash_entry);
                         return chunk_ref;
                     }
                     _ => panic!("Unexpected reply from BlobStore."),
@@ -339,7 +339,7 @@ impl<IT: Iterator<Item = Vec<u8>>> MsgHandler<Msg<IT>, Result<Reply, MsgError>> 
                         if chunk_it_opt.is_some() && entry.data_hash.is_some() {
                             let hash = hash::Hash { bytes: entry.data_hash.clone().unwrap() };
                             if let hash::Reply::HashKnown =
-                                   self.hash_index.send_reply(hash::Msg::HashExists(hash)) {
+                                   self.hash_index.hash_exists(hash) {
                                 // Short-circuit: We have the data.
                                 return reply_ok(Reply::Id(entry.id.unwrap()));
                             }

--- a/src/hat/key/mod.rs
+++ b/src/hat/key/mod.rs
@@ -121,7 +121,7 @@ impl Store {
         (backend: B)
          -> Result<Store, MsgError> {
         let ki_p = try!(Process::new(move || index::Index::new_for_testing()));
-        let hi_p = try!(Process::new(move || hash::Index::new_for_testing()));
+        let hi_p = hash::IndexProcess::new(try!(hash::Index::new_for_testing()));
         let bs_p = try!(Process::new(move || blob::Store::new_for_testing(backend, 1024)));
         Ok(Store {
             index: ki_p,


### PR DESCRIPTION
I have rewritten the hash::Index, so that it not longer is a separate thread. Instead references are shared using Arc<Mutex<Index>>.

This simplified the API significantly, since we no longer need wrap everything Msg and Reply types.