### PR TITLE
Convert "shutdown_after" into a poison system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,5 +35,5 @@ install:
 
 script:
   - cargo build --verbose
-  - cargo test --verbose
+  - RUST_LOG=error cargo test --verbose
   - cargo doc

--- a/src/hat/blob/index.rs
+++ b/src/hat/blob/index.rs
@@ -231,16 +231,16 @@ impl InternalBlobIndex {
 
 impl BlobIndex {
     pub fn new(path: &str) -> Result<BlobIndex, IndexError> {
-        BlobIndex::new_with_shutdown(path, None)
+        BlobIndex::new_with_poison(path, None)
     }
 
-    pub fn new_for_testing(shutdown: Option<i64>) -> Result<BlobIndex, IndexError> {
-        BlobIndex::new_with_shutdown(":memory:", shutdown)
+    pub fn new_for_testing(poison: Option<i64>) -> Result<BlobIndex, IndexError> {
+        BlobIndex::new_with_poison(":memory:", poison)
     }
 
-    pub fn new_with_shutdown(path: &str, shutdown: Option<i64>) -> Result<BlobIndex, IndexError> {
+    pub fn new_with_poison(path: &str, poison: Option<i64>) -> Result<BlobIndex, IndexError> {
         let index = try!(InternalBlobIndex::new(path));
-        Ok(BlobIndex(Arc::new(Mutex::new((index, shutdown)))))
+        Ok(BlobIndex(Arc::new(Mutex::new((index, poison)))))
     }
 
     fn lock(&self) -> MutexGuard<(InternalBlobIndex, Option<i64>)> {

--- a/src/hat/blob/mod.rs
+++ b/src/hat/blob/mod.rs
@@ -296,7 +296,7 @@ impl<B: StoreBackend> Store<B> {
 
     #[cfg(test)]
     pub fn new_for_testing(backend: B, max_blob_size: usize) -> Result<Store<B>, MsgError> {
-        let bi_p = try!(index::BlobIndex::new_for_testing(None));
+        let bi_p = try!(index::BlobIndex::new_for_testing());
         let mut bs = Store {
             backend: backend,
             blob_index: bi_p,

--- a/src/hat/hat.rs
+++ b/src/hat/hat.rs
@@ -253,8 +253,8 @@ impl<B: 'static + blob::StoreBackend + Clone + Send> HatRc<B> {
         // If provided, we cycle the possible poison values to give every process one.
         let mut poison = poison_after.iter().cycle();
 
-        let si_p = snapshot::SnapshotIndex::new_for_testing(poison.next().cloned()).unwrap();
-        let bi_p = blob::BlobIndex::new_for_testing(poison.next().cloned()).unwrap();
+        let si_p = snapshot::SnapshotIndex::new_for_testing().unwrap();
+        let bi_p = blob::BlobIndex::new_for_testing().unwrap();
         let hi_p = hash::HashIndex::new_for_testing(poison.next().cloned()).unwrap();
 
         let local_blob_index = bi_p.clone();
@@ -310,7 +310,7 @@ impl<B: 'static + blob::StoreBackend + Clone + Send> HatRc<B> {
             None => ":memory:".to_string(),
         };
 
-        let ki_p = try!(key::KeyIndex::new_with_poison(&key_index_path, poison_after));
+        let ki_p = try!(key::KeyIndex::new(&key_index_path));
 
         let local_ks = key::Store::new(ki_p.clone(),
                                        self.hash_index.clone(),

--- a/src/hat/hat.rs
+++ b/src/hat/hat.rs
@@ -1646,9 +1646,9 @@ mod tests {
 
         let mut run_until_error = || {
             try!(snapshot_files(&fam,
-                           vec![("name1", vec![0; 1000000]),
-                                ("name2", vec![1; 1000000]),
-                                ("name3", vec![2; 1000000])]));
+                                vec![("name1", vec![0; 1000000]),
+                                     ("name2", vec![1; 1000000]),
+                                     ("name3", vec![2; 1000000])]));
 
             try!(fam.flush());
             try!(hat.commit(&fam, None));

--- a/src/hat/hat.rs
+++ b/src/hat/hat.rs
@@ -1464,13 +1464,13 @@ mod tests {
         }
     }
 
-    fn snapshot_files(family: &Family, files: Vec<(&str, Vec<u8>)>) {
+    fn snapshot_files(family: &Family, files: Vec<(&str, Vec<u8>)>) -> Result<(), HatError> {
         for (name, contents) in files {
-            family.snapshot_direct(entry(name.bytes().collect()),
+            try!(family.snapshot_direct(entry(name.bytes().collect()),
                                  false,
-                                 Some(FileIterator::from_bytes(contents)))
-                .unwrap();
+                                 Some(FileIterator::from_bytes(contents))));
         }
+        Ok(())
     }
 
     #[test]

--- a/src/hat/key/index.rs
+++ b/src/hat/key/index.rs
@@ -287,16 +287,16 @@ impl InternalKeyIndex {
 
 impl KeyIndex {
     pub fn new(path: &str) -> Result<KeyIndex, IndexError> {
-        KeyIndex::new_with_shutdown(path, None)
+        KeyIndex::new_with_poison(path, None)
     }
 
-    pub fn new_for_testing(shutdown: Option<i64>) -> Result<KeyIndex, IndexError> {
-        KeyIndex::new_with_shutdown(":memory:", shutdown)
+    pub fn new_for_testing(poison: Option<i64>) -> Result<KeyIndex, IndexError> {
+        KeyIndex::new_with_poison(":memory:", poison)
     }
 
-    pub fn new_with_shutdown(path: &str, shutdown: Option<i64>) -> Result<KeyIndex, IndexError> {
+    pub fn new_with_poison(path: &str, poison: Option<i64>) -> Result<KeyIndex, IndexError> {
         let index = try!(InternalKeyIndex::new(path));
-        Ok(KeyIndex(Arc::new(Mutex::new((index, shutdown)))))
+        Ok(KeyIndex(Arc::new(Mutex::new((index, poison)))))
     }
 
     fn lock(&self) -> MutexGuard<(InternalKeyIndex, Option<i64>)> {

--- a/src/hat/key/mod.rs
+++ b/src/hat/key/mod.rs
@@ -120,7 +120,7 @@ impl Store {
     pub fn new_for_testing<B: 'static + blob::StoreBackend + Send + Clone>
         (backend: B)
          -> Result<Store, MsgError> {
-        let ki_p = try!(index::KeyIndex::new_for_testing(None));
+        let ki_p = try!(index::KeyIndex::new_for_testing());
         let hi_p = try!(hash::HashIndex::new_for_testing(None));
         let bs_p = try!(Process::new(move || blob::Store::new_for_testing(backend, 1024)));
         Ok(Store {

--- a/src/hat/process.rs
+++ b/src/hat/process.rs
@@ -172,7 +172,7 @@ impl<Msg: 'static + Send, Reply: 'static + Send, E> Process<Msg, Reply, E> {
             };
             while let Err(e) = do_loop() {
                 *poisoned.lock().unwrap() = true;  // This process is in a polluted state.
-                error!("Poisoned process: {:?}", e);
+                warn!("Poisoned process: {:?}", e);
             }
         });
 

--- a/src/hat/snapshot/mod.rs
+++ b/src/hat/snapshot/mod.rs
@@ -368,18 +368,16 @@ impl InternalSnapshotIndex {
 
 impl SnapshotIndex {
     pub fn new(path: &str) -> Result<SnapshotIndex, IndexError> {
-        SnapshotIndex::new_with_shutdown(path, None)
+        SnapshotIndex::new_with_poison(path, None)
     }
 
-    pub fn new_for_testing(shutdown: Option<i64>) -> Result<SnapshotIndex, IndexError> {
-        SnapshotIndex::new_with_shutdown(":memory:", shutdown)
+    pub fn new_for_testing(poison: Option<i64>) -> Result<SnapshotIndex, IndexError> {
+        SnapshotIndex::new_with_poison(":memory:", poison)
     }
 
-    pub fn new_with_shutdown(path: &str,
-                             shutdown: Option<i64>)
-                             -> Result<SnapshotIndex, IndexError> {
+    pub fn new_with_poison(path: &str, poison: Option<i64>) -> Result<SnapshotIndex, IndexError> {
         let index = try!(InternalSnapshotIndex::new(path));
-        Ok(SnapshotIndex(Arc::new(Mutex::new((index, shutdown)))))
+        Ok(SnapshotIndex(Arc::new(Mutex::new((index, poison)))))
     }
 
     fn lock(&self) -> MutexGuard<(InternalSnapshotIndex, Option<i64>)> {


### PR DESCRIPTION
After seeing an unrecoverable error a process becomes poisoned instead of crashing (includes the hash index, as its state is complicated).

Poisoned processes by default rejects messages (but may later support flush and reset).